### PR TITLE
Allow displaying columns with the same name (Rename duplicate field names) 

### DIFF
--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -2,6 +2,20 @@ import sqlalchemy
 import sqlparse
 import prettytable
 
+
+def unduplicate_field_names(field_names):
+    """ Append a number to duplicate field names to make them unique. """
+    res = []
+    for k in field_names:
+        if k in res:
+            i = 1
+            while k + '_' + str(i) in res:
+                i += 1
+            k += '_' + str(i)
+        res.append(k)
+    return res
+
+
 class ResultSet(list):
     def __init__(self, sqlaproxy, sql, config):
         self.keys = sqlaproxy.keys()
@@ -14,7 +28,7 @@ class ResultSet(list):
                 list.__init__(self, sqlaproxy.fetchmany(size=self.limit))
             else:
                 list.__init__(self, sqlaproxy.fetchall())
-            self.pretty = prettytable.PrettyTable(self.keys)
+            self.pretty = prettytable.PrettyTable(unduplicate_field_names(self.keys))
             for row in self:
                 self.pretty.add_row(row)
             self.pretty.set_style(self.style)


### PR DESCRIPTION
PrettyTable doesn't support having columns with the same name so we
rename them beforehand.

Note this only change the columns name when displayed with PrettyTable
