### PR TITLE
specify minimum sqlalchemy version required

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ version = '0.3.0'
 install_requires = [
     'prettytable',
     'ipython>=1.0',
-    'sqlalchemy',
+    'sqlalchemy>=0.6.7',
     'sqlparse',
 ]
 


### PR DESCRIPTION
ResultSet.sqlaproxy.returns_rows requires sqla 0.6.7 per http://docs.sqlalchemy.org/en/rel_0_6/core/connections.html?highlight=returns_rows.

On a related note, keys also isn't a method on ResultProxy until some time in 0.6, so working around a missing return_rows would likely require a fix there too.
