### PR TITLE
fixes configparser in python 2.x

### DIFF
--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -1,5 +1,5 @@
 import six
-from six.moves import configparser
+from six.moves import configparser as CP
 from sqlalchemy.engine.url import URL
 
 
@@ -9,7 +9,7 @@ def parse(cell, config):
         return {'connection': '', 'sql': ''}
     if parts[0].startswith('[') and parts[0].endswith(']'):
         section = parts[0].lstrip('[').rstrip(']')
-        parser = configparser()
+        parser = CP.ConfigParser()
         parser.read(config.dsn_filename)
         cfg_dict = dict(parser.items(section))
 


### PR DESCRIPTION
configparser is a module that has the constructor function so calling `configparser` before resulted in a `TypeError: 'module' object is not callable` error.

BTW, I was unable to run the tests to verify that this didn't break anything. I tried to follow the `HACKING.txt` instructions but ran into this:
```
$ python --version
Python 2.7.8
$ python bootstrap.py
Traceback (most recent call last):
  File "bootstrap.py", line 105, in <module>
    ws.find(pkg_resources.Requirement.parse(requirement)).location
AttributeError: 'NoneType' object has no attribute 'location'
```

Simply running `nosetest` I get `ERROR: Failure: NameError (name 'get_ipython' is not defined)`.