### PR TITLE
Standardize README to rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,10 @@ commands within IPython or IPython Notebook.
    :width: 600px
    :alt: screenshot of ipython-sql in the Notebook
 
-Examples::
+Examples
+--------
+
+.. code-block:: python
 
     In [1]: %load_ext sql
 


### PR DESCRIPTION
- Some links were written in markdown rather than rst
- Added Python code blocks (although this might might mess up SQL highlighting)
