### PR TITLE
Fix CSV method to work with Python 3

### DIFF
--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -3,7 +3,6 @@ import operator
 import types
 import csv
 import six
-from six.moves import cStringIO
 import codecs
 import os.path
 import sqlalchemy
@@ -32,26 +31,31 @@ class UnicodeWriter(object):
 
     def __init__(self, f, dialect=csv.excel, encoding="utf-8", **kwds):
         # Redirect output to a queue
-        self.queue = cStringIO.StringIO()
+        self.queue = six.StringIO()
         self.writer = csv.writer(self.queue, dialect=dialect, **kwds)
         self.stream = f
         self.encoder = codecs.getincrementalencoder(encoding)()
 
     def writerow(self, row):
-        _row = [s.encode("utf-8")
-                if hasattr(s, "encode")
-                else s
-                for s in row]
+        if six.PY2:
+            _row = [s.encode("utf-8")
+                    if hasattr(s, "encode")
+                    else s
+                    for s in row]
+        else:
+            _row = row
         self.writer.writerow(_row)
         # Fetch UTF-8 output from the queue ...
         data = self.queue.getvalue()
-        data = data.decode("utf-8")
-        # ... and reencode it into the target encoding
-        data = self.encoder.encode(data)
+        if six.PY2:
+           data = data.decode("utf-8")
+           # ... and reencode it into the target encoding
+           data = self.encoder.encode(data)
         # write to the target stream
         self.stream.write(data)
         # empty queue
         self.queue.truncate(0)
+        self.queue.seek(0)
 
     def writerows(self, rows):
         for row in rows:
@@ -212,13 +216,17 @@ class ResultSet(list, ColumnGuesserMixin):
     
     def csv(self, filename=None, **format_params):
         """Generate results in comma-separated form.  Write to ``filename`` if given.
-           Any other parameterw will be passed on to csv.writer."""
+           Any other parameters will be passed on to csv.writer."""
         if not self.pretty:
             return None # no results
         if filename:
-            outfile = open(filename, 'w')
+            encoding = format_params.get('encoding', 'utf-8')
+            if six.PY2:
+                outfile = open(filename, 'wb')
+            else:
+                outfile = open(filename, 'w', newline='', encoding=encoding)
         else:
-            outfile = cStringIO.StringIO()
+            outfile = six.StringIO()
         writer = UnicodeWriter(outfile, **format_params)
         writer.writerow(self.field_names)
         for row in self:


### PR DESCRIPTION
Just a couple of compatibility fixes for the CSV output function; in Python 3 there's no need for the encoding-decoding dance, as string objects are already unicode-aware. That fun job can be offloaded to the file stream object. 