### PR TITLE
New config option to return results directly to user namespace

### DIFF
--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -135,6 +135,10 @@ class ResultSet(list, ColumnGuesserMixin):
             if len(result) > 1:
                 raise KeyError('%d results for "%s"' % (len(result), key))
             return result[0]
+    def dict(self):
+        "Returns a dict built from the result set, with column names as keys"
+        return dict(zip(self.keys, zip(*self)))
+
     def DataFrame(self):
         "Returns a Pandas DataFrame instance built from the result set."
         import pandas as pd


### PR DESCRIPTION
Adds a new boolean config option column_local_vars  (default False). When true, instead of returning results into the `_` variable, the user's namespace is edited to add variables as lists of data, with names supplied by the query column names. This also obeys the config.autopandas options (returning pandas series instead of lists) and the config.feedback option (returning silently or printing a list of column names)

Minimal example:
```
In [1]: %load_ext sql

In [2]: %sql postgresql://localhost/test
Out[2]: 'Connected: None@test'

In [3]: %config SqlMagic.column_local_vars = True

In [4]: %sql select generate_series(1,5) xdata, random() ydata
5 rows affected.
Returning data to local variables [xdata, ydata]

In [5]: xdata
Out[5]: (1, 2, 3, 4, 5)

In [6]: ydata
Out[6]:
(0.953827208839357,
 0.16232542693615,
 0.632917185314,
 0.947700880933553,
 0.0648908540606499)
```