### PR TITLE
fix config help text formatting and typo

### DIFF
--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -27,10 +27,10 @@ class SqlMagic(Magics, Configurable):
     displaylimit = Int(0, config=True, help="Automatically limit the number of rows displayed (full result set is still stored)")
     autopandas = Bool(False, config=True, help="Return Pandas DataFrames instead of regular result sets")
     feedback = Bool(True, config=True, help="Print number of rows affected by DML")
-    dsn_filename = Unicode('odbc.ini', config=True, help="Path to DSN file. \
-                           When the first argument is of the form [section], \
-                           a sqlalchemy connection string is formed from the \
-                           matching section in the DSN file.")
+    dsn_filename = Unicode('odbc.ini', config=True, help="Path to DSN file. "
+                           "When the first argument is of the form [section], "
+                           "a sqlalchemy connection string is formed from the "
+                           "matching section in the DSN file.")
 
     def __init__(self, shell):
         Configurable.__init__(self, config=shell.config)

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -24,7 +24,7 @@ class SqlMagic(Magics, Configurable):
     autolimit = Int(0, config=True, help="Automatically limit the size of the returned result sets")
     style = Unicode('DEFAULT', config=True, help="Set the table printing style to any of prettytable's defined styles (currently DEFAULT, MSWORD_FRIENDLY, PLAIN_COLUMNS, RANDOM)")
     short_errors = Bool(True, config=True, help="Don't display the full traceback on SQL Programming Error")
-    displaylimit = Int(0, config=True, help="Automatic,ally limit the number of rows displayed (full result set is still stored)")
+    displaylimit = Int(0, config=True, help="Automatically limit the number of rows displayed (full result set is still stored)")
     autopandas = Bool(False, config=True, help="Return Pandas DataFrames instead of regular result sets")
     feedback = Bool(True, config=True, help="Print number of rows affected by DML")
     dsn_filename = Unicode('odbc.ini', config=True, help="Path to DSN file. \


### PR DESCRIPTION
Minor config help string fixes.

The intent is to go from this:
![screen shot 2015-01-10 at 2 41 09 pm](https://cloud.githubusercontent.com/assets/303866/5693168/f6ffc30e-98d6-11e4-854f-7578928a0b16.png)

To this:
![screen shot 2015-01-10 at 2 35 30 pm](https://cloud.githubusercontent.com/assets/303866/5693170/fe97f186-98d6-11e4-94af-388fe14027ae.png)
