### PR TITLE
Fixed local_ns leak

### DIFF
--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -68,7 +68,7 @@ class SqlMagic(Magics, Configurable):
 
         """
         # save globals and locals so they can be referenced in bind vars
-        user_ns = self.shell.user_ns
+        user_ns = self.shell.user_ns.copy()
         user_ns.update(local_ns)
 
         parsed = sql.parse.parse('%s\n%s' % (line, cell), self)

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -1,5 +1,6 @@
 from nose import with_setup
 from sql.magic import SqlMagic
+from textwrap import dedent
 import re
 
 ip = get_ipython()
@@ -101,6 +102,15 @@ def test_displaylimit():
     ip.run_line_magic('config',  "SqlMagic.displaylimit = 1")
     result = ip.run_line_magic('sql',  "sqlite:// SELECT * FROM writer;")
     assert result._repr_html_().count("<tr>") == 2
+
+@with_setup(_setup, _teardown)
+def test_userns_not_changed():
+    ip.run_cell(dedent("""
+    def function():
+        local_var = 'local_val'
+        %sql sqlite:// INSERT INTO test VALUES (2, 'bar');
+    function()"""))
+    assert 'local_var' not in ip.user_ns
 
 """
 def test_control_feedback():


### PR DESCRIPTION
Fixed a bug where variables in the local namespace would get leaked into the user namespace when the sql magic was used.