### PR TITLE
Fix "connection busy with another command" error for SQL Server

### DIFF
--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -13,6 +13,7 @@ class Connection(object):
         except: # TODO: bare except; but what's an ArgumentError?
             print(self.tell_format())
             raise 
+        self.dialect = engine.url.get_dialect()
         self.metadata = sqlalchemy.MetaData(bind=engine)
         self.name = self.assign_name(engine)
         self.session = engine.connect() 

--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -275,7 +275,9 @@ def run(conn, sql, config, user_namespace):
             txt = sqlalchemy.sql.text(statement)
             result = conn.session.execute(txt, user_namespace)
             try:
-                conn.session.execute('commit')
+                # mssql has autocommit
+                if 'mssql' not in str(conn.dialect):
+                    conn.session.execute('commit')
             except sqlalchemy.exc.OperationalError: 
                 pass # not all engines can commit
             if result and config.feedback:


### PR DESCRIPTION
The 'commit' command executed in run.py causes a "connection busy" error for SQL Server. 

Since autocommit mode is the default transaction management mode of the SQL Server Database Engine, i.e., every Transact-SQL statement is committed or rolled back when it completes, the 'commit' in run.py is unnecessary.