### PR TITLE
update for Jupyter 4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,8 @@ from setuptools import setup, find_packages
 import sys, os
 
 here = os.path.abspath(os.path.dirname(__file__))
-README = open(os.path.join(here, 'README.rst')).read()
-NEWS = open(os.path.join(here, 'NEWS.txt')).read()
-
-
-version = '0.3.7.1'
-
+README = 'Slightly modified version for Jupyter 4 based on ipython-sql from Catherine Devlin at https://github.com/catherinedevlin/ipython-sql'
+version = '0.3.7.2'
 install_requires = [
     'prettytable',
     'ipython>=1.0',

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -1,7 +1,7 @@
 import re
 from IPython.core.magic import Magics, magics_class, cell_magic, line_magic, needs_local_scope
-from IPython.config.configurable import Configurable
-from IPython.utils.traitlets import Bool, Int, Unicode
+from traitlets.config.configurable import Configurable
+from traitlets import Bool, Int, Unicode
 try:
     from pandas.core.frame import DataFrame, Series
 except ImportError:

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -1,6 +1,6 @@
 from sql.parse import parse
 from six.moves import configparser
-from IPython.config.configurable import Configurable
+from traitlets.config.configurable import Configurable
 
 empty_config = Configurable()
 


### PR DESCRIPTION
When running under iPython4 (Jupyter) there are warnings about deprecated calls when calling load_ext sql
```
/opt/conda/lib/python3.4/site-packages/IPython/config.py:13: ShimWarning: The `IPython.config` package has been deprecated. You should import from traitlets.config instead.
  "You should import from traitlets.config instead.", ShimWarning)
/opt/conda/lib/python3.4/site-packages/IPython/utils/traitlets.py:5: UserWarning: IPython.utils.traitlets has moved to a top-level traitlets package.
  warn("IPython.utils.traitlets has moved to a top-level traitlets package.")
```
This commit fixes that, and also gets around the ascii character set problems in reading in the README and NEWS files when compiling. 

Signed-off-by: Mark McCahill <mark.mccahill@duke.edu>