### PR TITLE
MagicArguments for ipython-sql: -connections, -close, -creator, -sect…

### DIFF
--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -7,30 +7,35 @@ class Connection(object):
     def tell_format(cls):
         return "Format: (postgresql|mysql)://username:password@hostname/dbname, or one of %s" \
                % str(cls.connections.keys())
-    def __init__(self, connect_str=None):
+    def __init__(self, connect_str=None, creator=None):
         try:
-            engine = sqlalchemy.create_engine(connect_str)
+            if creator:
+                engine = sqlalchemy.create_engine(connect_str, creator=creator)
+            else:
+                engine = sqlalchemy.create_engine(connect_str)
         except: # TODO: bare except; but what's an ArgumentError?
             print(self.tell_format())
-            raise 
+            raise
         self.dialect = engine.url.get_dialect()
         self.metadata = sqlalchemy.MetaData(bind=engine)
         self.name = self.assign_name(engine)
-        self.session = engine.connect() 
+        self.session = engine.connect()
         self.connections[self.name] = self
         self.connections[str(self.metadata.bind.url)] = self
         Connection.current = self
+
     @classmethod
-    def get(cls, descriptor):
+    def get(cls, descriptor, creator=None):
         if isinstance(descriptor, Connection):
             cls.current = descriptor
         elif descriptor:
             conn = cls.connections.get(descriptor) or \
-                   cls.connections.get(descriptor.lower()) 
+                   cls.connections.get(descriptor.lower())
             if conn:
                 cls.current = conn
             else:
-                cls.current = Connection(descriptor)
+                # http://docs.sqlalchemy.org/en/rel_0_9/core/engines.html#custom-dbapi-connect-arguments
+                cls.current = Connection(descriptor, creator)
         if cls.current:
             return cls.current
         else:
@@ -44,3 +49,22 @@ class Connection(object):
             name = '%s_%d' % (core_name, incrementer)
             incrementer += 1
         return name
+
+    @classmethod
+    def _close(cls, descriptor):
+        if isinstance(descriptor, Connection):
+            conn = descriptor
+        else:
+            conn = cls.connections.get(descriptor) or \
+                   cls.connections.get(descriptor.lower())
+        if not conn:
+            raise Exception("Could not close connection because it was not found amongst these: %s" \
+                %str(cls.connections.keys()))
+        cls.connections.pop(conn.name)
+        cls.connections.pop(str(conn.metadata.bind.url))
+        conn.session.close()
+
+    def close(self):
+        self.__class__._close(self)
+
+

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -2,27 +2,9 @@ import six
 from six.moves import configparser as CP
 from sqlalchemy.engine.url import URL
 
+def connection_from_dsn_section(section, config):
+    parser = CP.ConfigParser()
+    parser.read(config.dsn_filename)
+    cfg_dict = dict(parser.items(section))
+    return str(URL(**cfg_dict))
 
-def parse(cell, config):
-    parts = [part.strip() for part in cell.split(None, 1)]
-    if not parts:
-        return {'connection': '', 'sql': ''}
-    if parts[0].startswith('[') and parts[0].endswith(']'):
-        section = parts[0].lstrip('[').rstrip(']')
-        parser = CP.ConfigParser()
-        parser.read(config.dsn_filename)
-        cfg_dict = dict(parser.items(section))
-
-        connection = str(URL(**cfg_dict))
-        sql = parts[1] if len(parts) > 1 else ''
-    elif '@' in parts[0] or '://' in parts[0]:
-        connection = parts[0]
-        if len(parts) > 1:
-            sql = parts[1]
-        else:
-            sql = ''
-    else:
-        connection = ''
-        sql = cell
-    return {'connection': connection.strip(),
-            'sql': sql.strip()}


### PR DESCRIPTION
Hello, so I've been playing around with ipython-sql recently and looking to finally switch over from working natively with psycopg2. There were a few things that I found somewhat lacking. 

One is connection state management - getting a list of open connections is currently especially verbose: (sql.connection.Connection.connections). As well as the ability to close the connections. 

Another thing I was missing was the ability to use psycopg2.connect natively (which sqlalchemy supports via the creator argument but ipython-sql currently does not). (http://docs.sqlalchemy.org/en/rel_0_9/core/engines.html#custom-dbapi-connect-arguments) 

Also unless there are strong reasons against it I would propose switching to using magic_arguments vs a home-brewed parser, since the later can become exceedingly complex and confusing as functionality is added. With this patch the old connection and sql block format is kept, but connecting by dsn file section would now be through `%sql -section <section_name>` and instead of `PERSIST` it would be `%sql -persist`. 

I haven't really kept up with IPython so let me know if I'm missing something :) 
