### PR TITLE
prefer new traitlets packages

### DIFF
--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -1,7 +1,11 @@
 import re
 from IPython.core.magic import Magics, magics_class, cell_magic, line_magic, needs_local_scope
-from IPython.config.configurable import Configurable
-from IPython.utils.traitlets import Bool, Int, Unicode
+try:
+    from traitlets.config.configurable import Configurable
+    from traitlets import Bool, Int, Unicode
+except ImportError:
+    from IPython.config.configurable import Configurable
+    from IPython.utils.traitlets import Bool, Int, Unicode
 try:
     from pandas.core.frame import DataFrame, Series
 except ImportError:

--- a/src/tests/test_parse.py
+++ b/src/tests/test_parse.py
@@ -1,6 +1,9 @@
 from sql.parse import parse
 from six.moves import configparser
-from IPython.config.configurable import Configurable
+try:
+    from traitlets.config.configurable import Configurable
+except ImportError:
+    from IPython.config.configurable import Configurable
 
 empty_config = Configurable()
 


### PR DESCRIPTION
to suppress warnings.  Both modules were separated from IPython around the same time so grouping the `ImportError`s should be fine.

