### PR TITLE
Fix truth value of a DataFrame error

### DIFF
--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -86,7 +86,7 @@ class SqlMagic(Magics, Configurable):
         try:
             result = sql.run.run(conn, parsed['sql'], self, user_ns)
 
-            if result and ~isinstance(result, str) and self.column_local_vars:
+            if result is not None and ~isinstance(result, str) and self.column_local_vars:
                 #Instead of returning values, set variables directly in the
                 #users namespace. Variable names given by column names
 


### PR DESCRIPTION
On Python 3, I came across the following error, when `autopandas` is set to `True`

`The truth value of a DataFrame is ambiguous.  Use a.empty, a.bool(), a.item(), a.any() or a.all().`

This is a fix for this, tested on my own fork.