### PR TITLE
Update readme to address issue 51

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -167,6 +167,8 @@ only the screen display is truncated.
 
     In[3]: %config SqlMagic.feedback = False
 
+Please note: if you have autopandas set to true, the displaylimit option will not apply. You can set the pandas display limit by using the pandas ``max_rows`` option as described in the `pandas documentation <http://pandas.pydata.org/pandas-docs/version/0.18.1/options.html#frequently-used-options>`_.
+
 Pandas
 ------
 


### PR DESCRIPTION
This commit clarifies the issue raised in https://github.com/catherinedevlin/ipython-sql/issues/51.  

The issue is that the `displaylimit` config option does not work if the `autopandas` config option is set to true.

Please view the discussion in the issue for details.

I ran into this issue as well and spent some time digging into this problem. I don't think it is resolvable, but I do think including this note in the readme will save people time.