### PR TITLE
Add autocommit setting to connect HiveServer2 with impyla

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -150,6 +150,13 @@ to specify it in the connection string::
 
     mysql+pymysql://scott:tiger@localhost/foo?charset=utf8
 
+Note that ``impala`` connecion with `impyla`_  for HiveServer2 requires to disable autocommit::
+
+    %config SqlMagic.autocommit=False
+    %sql impala://hserverhost:port/default?kerberos_service_name=hive&auth_mechanism=GSSAPI
+
+.. _impyla: https://github.com/cloudera/impyla
+
 Configuration
 -------------
 
@@ -165,6 +172,9 @@ only the screen display is truncated.
     In [2]: %config SqlMagic
     SqlMagic options
     --------------
+    SqlMagic.autocommit=<Bool>
+        Current: True
+        Set autocommit mode
     SqlMagic.autolimit=<Int>
         Current: 0
         Automatically limit the size of the returned result sets

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -36,6 +36,7 @@ class SqlMagic(Magics, Configurable):
                            "When the first argument is of the form [section], "
                            "a sqlalchemy connection string is formed from the "
                            "matching section in the DSN file.")
+    autocommit = Bool(True, config=True, help="Set autocommit mode")
 
 
     def __init__(self, shell):

--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -276,7 +276,7 @@ def run(conn, sql, config, user_namespace):
             result = conn.session.execute(txt, user_namespace)
             try:
                 # mssql has autocommit
-                if 'mssql' not in str(conn.dialect) and config.autocommit:
+                if config.autocommit and ('mssql' not in str(conn.dialect)):
                     conn.session.execute('commit')
             except sqlalchemy.exc.OperationalError: 
                 pass # not all engines can commit

--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -276,7 +276,7 @@ def run(conn, sql, config, user_namespace):
             result = conn.session.execute(txt, user_namespace)
             try:
                 # mssql has autocommit
-                if 'mssql' not in str(conn.dialect):
+                if 'mssql' not in str(conn.dialect) and config.autocommit:
                     conn.session.execute('commit')
             except sqlalchemy.exc.OperationalError: 
                 pass # not all engines can commit


### PR DESCRIPTION
I tried to connect hiverserver2 with [impyla](https://github.com/cloudera/impyla) but it caused an error on executing `commit` in `run.py`. To avoid this problem, I added a new config `autocommit` to set autocommit mode. See also #53 .