### PR TITLE
commenting out code that dies in some browsers

### DIFF
--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -154,6 +154,10 @@ class SqlMagic(Magics, Configurable):
 
 def load_ipython_extension(ip):
     """Load the extension in IPython."""
-    js = "IPython.CodeCell.config_defaults.highlight_modes['magic_sql'] = {'reg':[/^%%sql/]};"
-    display_javascript(js, raw=True)
+
+    # this fails in both Firefox and Chrome for OS X.
+    # I get the error: TypeError: IPython.CodeCell.config_defaults is undefined
+    
+    # js = "IPython.CodeCell.config_defaults.highlight_modes['magic_sql'] = {'reg':[/^%%sql/]};"
+    # display_javascript(js, raw=True)
     ip.register_magics(SqlMagic)


### PR DESCRIPTION
confirmed failure in firefox and chrome for os x

The error I got was `TypeError: IPython.CodeCell.config_defaults is undefined`