### PR TITLE
call __repr__() on url rather than __str__() to hide password

### DIFF
--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -26,13 +26,12 @@ class Connection(object):
         self.name = self.assign_name(engine)
         self.session = engine.connect()
         self.connections[self.name] = self
-        self.connections[str(self.metadata.bind.url)] = self
+        self.connections[repr(self.metadata.bind.url)] = self
         Connection.current = self
 
     @classmethod
     def set(cls, descriptor):
         "Sets the current database connection"
-
         if descriptor:
             if isinstance(descriptor, Connection):
                 cls.current = descriptor
@@ -69,5 +68,5 @@ class Connection(object):
                 template = ' * {}'
             else:
                 template = '   {}'
-            result.append(template.format(engine_url.__repr__()))
+            result.append(template.format(key))
         return '\n'.join(result)


### PR DESCRIPTION
calling `__repr__()` rather than `__str__()` on the connection url object hides the password.
this should close #91 