### PR TITLE
remove pgspecial as install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ install_requires = [
     'sqlalchemy>=0.6.7',
     'sqlparse',
     'six',
-    'pgspecial',
     'ipython-genutils>=0.1.0',
 ]
 


### PR DESCRIPTION
I hope I'm correct in this removal. My understanding is that we are unopinionated about which database should be used.