### PR TITLE
Update setup.py with encoding.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ from setuptools import setup, find_packages
 import os
 
 here = os.path.abspath(os.path.dirname(__file__))
-README = open(os.path.join(here, 'README.rst')).read()
-NEWS = open(os.path.join(here, 'NEWS.txt')).read()
+README = open(os.path.join(here, 'README.rst'), encoding='utf-8').read()
+NEWS = open(os.path.join(here, 'NEWS.txt'), encoding='utf-8').read()
 
 
 version = '0.3.9'


### PR DESCRIPTION
Added utf-8 encoding, to fix the following error:

P.S. Thanks for the wonderful tool you've created! :+1: 

```python
Traceback (most recent call last):
  File "setup.py", line 5, in <module>
    README = open(os.path.join(here, 'README.rst')).read()
  File "/anaconda/envs/nextgentel-recommender/lib/python3.5/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 9375: ordinal not in range(128)
```