### PR TITLE
Pin version of prettytable to allow poetry install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-prettytable
+prettytable=0.7.2
 ipython>=1.0
 sqlalchemy>=0.6.7
 sqlparse


### PR DESCRIPTION
- Pin version of `prettytable` to latest (`0.7.2`) as there seems to be a problem with the `7` release

I was unable to `poetry add --dev ipython-sql` without this.