### PR TITLE
Add SqlMagic option to suppress printing of connection string.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -177,47 +177,45 @@ only the screen display is truncated.
 
 .. code-block:: python
 
-    In [2]: %config SqlMagic
-    SqlMagic options
-    --------------
-SqlMagic options
---------------
-SqlMagic.autocommit=<Bool>
-    Current: True
-    Set autocommit mode
-SqlMagic.autolimit=<Int>
-    Current: 0
-    Automatically limit the size of the returned result sets
-SqlMagic.autopandas=<Bool>
-    Current: False
-    Return Pandas DataFrames instead of regular result sets
-SqlMagic.column_local_vars=<Bool>
-    Current: False
-    Return data into local variables from column names
-SqlMagic.displaycon=<Bool>
-    Current: False
-    Show connection string after execute
-SqlMagic.displaylimit=<Int>
-    Current: None
-    Automatically limit the number of rows displayed (full result set is still
-    stored)
-SqlMagic.dsn_filename=<Unicode>
-    Current: 'odbc.ini'
-    Path to DSN file. When the first argument is of the form [section], a
-    sqlalchemy connection string is formed from the matching section in the DSN
-    file.
-SqlMagic.feedback=<Bool>
-    Current: False
-    Print number of rows affected by DML
-SqlMagic.short_errors=<Bool>
-    Current: True
-    Don't display the full traceback on SQL Programming Error
-SqlMagic.style=<Unicode>
-    Current: 'DEFAULT'
-    Set the table printing style to any of prettytable's defined styles
-    (currently DEFAULT, MSWORD_FRIENDLY, PLAIN_COLUMNS, RANDOM)
+   In [2]: %config SqlMagic
+   SqlMagic options
+   --------------
+   SqlMagic.autocommit=<Bool>
+       Current: True
+       Set autocommit mode
+   SqlMagic.autolimit=<Int>
+       Current: 0
+       Automatically limit the size of the returned result sets
+   SqlMagic.autopandas=<Bool>
+       Current: False
+       Return Pandas DataFrames instead of regular result sets
+   SqlMagic.column_local_vars=<Bool>
+       Current: False
+       Return data into local variables from column names
+   SqlMagic.displaycon=<Bool>
+       Current: False
+       Show connection string after execute
+   SqlMagic.displaylimit=<Int>
+       Current: None
+       Automatically limit the number of rows displayed (full result set is still
+       stored)
+   SqlMagic.dsn_filename=<Unicode>
+       Current: 'odbc.ini'
+       Path to DSN file. When the first argument is of the form [section], a
+       sqlalchemy connection string is formed from the matching section in the DSN
+       file.
+   SqlMagic.feedback=<Bool>
+       Current: False
+       Print number of rows affected by DML
+   SqlMagic.short_errors=<Bool>
+       Current: True
+       Don't display the full traceback on SQL Programming Error
+   SqlMagic.style=<Unicode>
+       Current: 'DEFAULT'
+       Set the table printing style to any of prettytable's defined styles
+       (currently DEFAULT, MSWORD_FRIENDLY, PLAIN_COLUMNS, RANDOM)
 
-In[3]: %config SqlMagic.feedback = False
+   In[3]: %config SqlMagic.feedback = False
 
 Please note: if you have autopandas set to true, the displaylimit option will not apply. You can set the pandas display limit by using the pandas ``max_rows`` option as described in the `pandas documentation <http://pandas.pydata.org/pandas-docs/version/0.18.1/options.html#frequently-used-options>`_.
 

--- a/README.rst
+++ b/README.rst
@@ -180,31 +180,44 @@ only the screen display is truncated.
     In [2]: %config SqlMagic
     SqlMagic options
     --------------
-    SqlMagic.autocommit=<Bool>
-        Current: True
-        Set autocommit mode
-    SqlMagic.autolimit=<Int>
-        Current: 0
-        Automatically limit the size of the returned result sets
-    SqlMagic.autopandas=<Bool>
-        Current: False
-        Return Pandas DataFrames instead of regular result sets
-    SqlMagic.displaylimit=<Int>
-        Current: 0
-        Automatically limit the number of rows displayed (full result set is still
-        stored)
-    SqlMagic.feedback=<Bool>
-        Current: True
-        Print number of rows affected by DML
-    SqlMagic.short_errors=<Bool>
-        Current: True
-        Don't display the full traceback on SQL Programming Error
-    SqlMagic.style=<Unicode>
-        Current: 'DEFAULT'
-        Set the table printing style to any of prettytable's defined styles
-        (currently DEFAULT, MSWORD_FRIENDLY, PLAIN_COLUMNS, RANDOM)
+SqlMagic options
+--------------
+SqlMagic.autocommit=<Bool>
+    Current: True
+    Set autocommit mode
+SqlMagic.autolimit=<Int>
+    Current: 0
+    Automatically limit the size of the returned result sets
+SqlMagic.autopandas=<Bool>
+    Current: False
+    Return Pandas DataFrames instead of regular result sets
+SqlMagic.column_local_vars=<Bool>
+    Current: False
+    Return data into local variables from column names
+SqlMagic.displaycon=<Bool>
+    Current: False
+    Show connection string after execute
+SqlMagic.displaylimit=<Int>
+    Current: None
+    Automatically limit the number of rows displayed (full result set is still
+    stored)
+SqlMagic.dsn_filename=<Unicode>
+    Current: 'odbc.ini'
+    Path to DSN file. When the first argument is of the form [section], a
+    sqlalchemy connection string is formed from the matching section in the DSN
+    file.
+SqlMagic.feedback=<Bool>
+    Current: False
+    Print number of rows affected by DML
+SqlMagic.short_errors=<Bool>
+    Current: True
+    Don't display the full traceback on SQL Programming Error
+SqlMagic.style=<Unicode>
+    Current: 'DEFAULT'
+    Set the table printing style to any of prettytable's defined styles
+    (currently DEFAULT, MSWORD_FRIENDLY, PLAIN_COLUMNS, RANDOM)
 
-    In[3]: %config SqlMagic.feedback = False
+In[3]: %config SqlMagic.feedback = False
 
 Please note: if you have autopandas set to true, the displaylimit option will not apply. You can set the pandas display limit by using the pandas ``max_rows`` option as described in the `pandas documentation <http://pandas.pydata.org/pandas-docs/version/0.18.1/options.html#frequently-used-options>`_.
 

--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -45,7 +45,7 @@ class Connection(object):
         Connection.current = self
 
     @classmethod
-    def set(cls, descriptor):
+    def set(cls, descriptor, displaycon):
         "Sets the current database connection"
 
         if descriptor:
@@ -55,8 +55,10 @@ class Connection(object):
                 existing = rough_dict_get(cls.connections, descriptor)
             cls.current = existing or Connection(descriptor)
         else:
+
             if cls.connections:
-                print(cls.connection_list())
+                if displaycon:
+                    print(cls.connection_list())
             else:
                 if os.getenv('DATABASE_URL'):
                     cls.current = Connection(os.getenv('DATABASE_URL'))

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -26,6 +26,7 @@ class SqlMagic(Magics, Configurable):
 
     Provides the %%sql magic."""
 
+    displaycon = Bool(True, config=True, help="Show connection string after execute")
     autolimit = Int(0, config=True, allow_none=True, help="Automatically limit the size of the returned result sets")
     style = Unicode('DEFAULT', config=True, help="Set the table printing style to any of prettytable's defined styles (currently DEFAULT, MSWORD_FRIENDLY, PLAIN_COLUMNS, RANDOM)")
     short_errors = Bool(True, config=True, help="Don't display the full traceback on SQL Programming Error")
@@ -82,7 +83,7 @@ class SqlMagic(Magics, Configurable):
         parsed = sql.parse.parse('%s\n%s' % (line, cell), self)
         flags = parsed['flags']
         try:
-            conn = sql.connection.Connection.set(parsed['connection'])
+            conn = sql.connection.Connection.set(parsed['connection'], displaycon=self.displaycon)
         except Exception as e:
             print(e)
             print(sql.connection.Connection.tell_format())


### PR DESCRIPTION
This PR is to solve [issue 126](https://github.com/catherinedevlin/ipython-sql/issues/126) raised by @TobiasSkovgaardJepsen.

I add a config flag `SqlMagic.displaycon` which when set to `False` will suppress the printing of the connection string after executing any SQL statements.

Since connection credentials are often included in the SQAlchemy connection string, it is helpful to be able to suppress printing it.

## Default Behavior
```
In [1]: %load_ext sql
   ...: %sql sqlite:////home/jovyan/shared/sqlite-tutorial/chinook.db
   ...: %sql SELECT trackid, name, composer, unitprice FROM tracks LIMIT 5
   ...:
   ...:
 * sqlite:////home/jovyan/shared/sqlite-tutorial/chinook.db
Done.
Out[1]:
[(1, 'For Those About To Rock (We Salute You)', 'Angus Young, Malcolm Young, Brian Johnson', 0.99),
 (2, 'Balls to the Wall', None, 0.99),
 (3, 'Fast As a Shark', 'F. Baltes, S. Kaufman, U. Dirkscneider & W. Hoffman', 0.99),
 (4, 'Restless and Wild', 'F. Baltes, R.A. Smith-Diesel, S. Kaufman, U. Dirkscneider & W. Hoffman', 0.99),
 (5, 'Princess of the Dawn', 'Deaffy & R.A. Smith-Diesel', 0.99)]
```

## New Optional Behavior
```
In [1]: %load_ext sql
   ...: %sql sqlite:////home/jovyan/shared/sqlite-tutorial/chinook.db
   ...: %config SqlMagic.displaycon=False
   ...: %sql SELECT trackid, name, composer, unitprice FROM tracks LIMIT 5
   ...:
   ...:
Done.
Out[1]:
[(1, 'For Those About To Rock (We Salute You)', 'Angus Young, Malcolm Young, Brian Johnson', 0.99),
 (2, 'Balls to the Wall', None, 0.99),
 (3, 'Fast As a Shark', 'F. Baltes, S. Kaufman, U. Dirkscneider & W. Hoffman', 0.99),
 (4, 'Restless and Wild', 'F. Baltes, R.A. Smith-Diesel, S. Kaufman, U. Dirkscneider & W. Hoffman', 0.99),
 (5, 'Princess of the Dawn', 'Deaffy & R.A. Smith-Diesel', 0.99)]
```

All tests pass.

```
$ ./run_tests.sh
=================================================== test session starts ===================================================
platform linux -- Python 3.5.5, pytest-3.5.1, py-1.5.3, pluggy-0.6.0
rootdir: /home/jovyan/ipython-sql, inifile:
plugins: remotedata-0.2.1, openfiles-0.3.0, doctestplus-0.1.3, arraydiff-0.2
collected 36 items

src/tests/test_column_guesser.py ........                                                                           [ 22%]
src/tests/test_magic.py .......................                                                                     [ 86%]
src/tests/test_parse.py .....                                                                                       [100%]

================================================ 36 passed in 1.11 seconds ================================================
Out[1]: 0
```