### PR TITLE
Add support for running queries from files

### DIFF
--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -347,6 +347,8 @@ def _commit(conn, config):
 
 def run(conn, sql, config, user_namespace):
     if sql.strip():
+        if os.path.isfile(sql):
+            sql = open(sql, 'r').read().strip()
         for statement in sqlparse.split(sql):
             first_word = sql.strip().split()[0].lower()
             if first_word == 'begin':

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -218,6 +218,17 @@ def test_csv_to_file(ip):
             assert len(content.splitlines()) == 3
 
 
+def test_sql_from_file(ip):
+    ip.run_line_magic('config', "SqlMagic.autopandas = False")
+    with tempfile.TemporaryDirectory() as tempdir:
+        fname = os.path.join(tempdir, 'test.sql')
+        with open(fname, 'rw') as tempf:
+            tempf.write("SELECT * FROM test;")
+        result = runsql(ip, fname)
+        assert result.dict()['n'] == (1, 2)
+        
+
+            
 def test_dict(ip):
     result = runsql(ip, "SELECT * FROM author;")
     result = result.dict()


### PR DESCRIPTION
This PR adds a support to run queries written in files using the following syntax:

    %sql filename

This is useful e.g. with excessively long queries that the user might want to keep as a separate file or when reusing existing codebase.