### PR TITLE
(actually :) Pin version of prettytable to allow poetry install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ NEWS = open(os.path.join(here, 'NEWS.txt'), encoding='utf-8').read()
 version = '0.3.9'
 
 install_requires = [
-    'prettytable',
+    'prettytable<1',
     'ipython>=1.0',
     'sqlalchemy>=0.6.7',
     'sqlparse',


### PR DESCRIPTION
In a previous commit(#136), @milesrichardson is pinning the `prettytable` dep version in `requirements.txt`.

PyPI indeed wrongly lists a non-existent version `7` for `prettytable`.

However, even after accounting for that in `requirements.txt`, it still leads to `ipython-sql` not being installable with eg `poetry`.

```
$ poetry add ipython-sql

[EnvCommandError]                                                                                                                 
Command ['python', '-m', 'pip', 'install', '--no-deps', '-U', 'prettytable==7'] errored with the following output:                                           
Collecting prettytable==7                                                                                                                      
  ERROR: Could not find a version that satisfies the requirement prettytable==7 (from versions: 0.3, 0.4, 0.5, 0.6, 0.6.1, 0.7, 0.7.1, 0.7.2)  
ERROR: No matching distribution found for prettytable==7            
```

This PR fixes that by constraining prettytable to below version 1 in `setup.py`