### PR TITLE
Fixed wrong version specifier

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-prettytable=0.7.2
+prettytable==0.7.2
 ipython>=1.0
 sqlalchemy>=0.6.7
 sqlparse

--- a/src/tests/test_magic.py
+++ b/src/tests/test_magic.py
@@ -101,7 +101,8 @@ def test_autolimit(ip):
 def test_persist(ip):
     runsql(ip, "")
     ip.run_cell("results = %sql SELECT * FROM test;")
-    ip.runcode("results_dframe = results.DataFrame()")
+    # ip.runcode("results_dframe = results.DataFrame()")
+    ip.run_cell("results_dframe = results.DataFrame()")
     runsql(ip, 'PERSIST results_dframe')
     persisted = runsql(ip, 'SELECT * FROM results_dframe')
     assert 'foo' in str(persisted)


### PR DESCRIPTION
It failed when using  'pip install -r requirement.txt' or 'pipenv install -r requirement.txt'

PEP-440 says exact version specifier is '==' (double equal)
https://www.python.org/dev/peps/pep-0440/#version-specifiers
