### PR TITLE
Fixed wrong version specifier

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-prettytable=0.7.2
+prettytable==0.7.2
 ipython>=1.0
 sqlalchemy>=0.6.7
 sqlparse


### PR DESCRIPTION
It failed when running 'pip install -r requirement.txt'

PEP-440 says exact version specifier is '==' (double equal)
https://www.python.org/dev/peps/pep-0440/#version-specifiers
