### PR TITLE
Added AWS Athena to the autocommit blacklist dialects

### DIFF
--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -328,7 +328,7 @@ class FakeResultProxy(object):
 
 # some dialects have autocommit
 # specific dialects break when commit is used:
-_COMMIT_BLACKLIST_DIALECTS = ('mssql', 'clickhouse', 'teradata')
+_COMMIT_BLACKLIST_DIALECTS = ('mssql', 'clickhouse', 'teradata', 'athena')
 
 
 def _commit(conn, config):


### PR DESCRIPTION
We are trying to use the SQL magic with AWS Athena, we noticed that Athena doesn't support autocommit.