### PR TITLE
Support passing connect_args to sqlalchemy

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -150,3 +150,8 @@ Deleted Plugin import left behind in 0.2.2
 * bugfix in executing column_local_vars (thanks tebeka)
 * pgspecial installation optional (thanks jstoebel and arjoe)
 * conceal passwords in connection strings (thanks jstoebel)
+
+0.3.9
+-----
+
+* Restored Python 2 compatibility (thanks tokenmathguy)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+psycopg2
+pandas
+pytest
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+prettytable
+ipython>=1.0
+sqlalchemy>=0.6.7
+sqlparse
+six
+ipython-genutils>=0.1.0

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from io import open
 from setuptools import setup, find_packages
 import os
 

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -18,7 +18,6 @@ from sqlalchemy.exc import ProgrammingError, OperationalError
 import sql.connection
 import sql.parse
 import sql.run
-import pytest
 
 @magics_class
 class SqlMagic(Magics, Configurable):

--- a/src/tests/run_tests.sh
+++ b/src/tests/run_tests.sh
@@ -1,1 +1,0 @@
-ipython -c "import nose; nose.run()"

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py27,py36
+
+[testenv]
+deps = pytest
+       -rrequirements.txt
+       -rrequirements-dev.txt
+commands =
+    ipython -c "import pytest; pytest.main(['.'])"


### PR DESCRIPTION
Certain arguments cannot be passed directly via the DSN when connecting. One notable example is search_path when using the `psycopg2` driver to connect to a postgres database. These changes allow a user to pass a connect_args dict along with the dsn during the connection process.

For example this examples fails:
```
In [1]: %sql postgresql://user:pass@localhost:5432/db?search_path=myschema
(psycopg2.ProgrammingError) invalid dsn: invalid connection option "search_path"
```

The `connect_args` can either be passed as a literal json string or as a bindvar matching the other bindvar syntax in this project.

Aside: also fixed a previously failing test `test_persist` in `test_magic.py`