### PR TITLE
Minor Fixes for dsn.ini

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -186,8 +186,8 @@ Connection arguments not whitelisted by SQLALchemy can be provided as
 a flag with (-a|--connection_arguments)the connection string as a JSON string.
 See `SQLAlchemy Args`_.
 
-    %sql --connection_arguments {"timeout":10,"mode":"ro"} sqlite:// SELECT * FROM work;
-    %sql -a '{"timeout":10, "mode":"ro"}' sqlite:// SELECT * from work;
+    | %sql --connection_arguments {"timeout":10,"mode":"ro"} sqlite:// SELECT * FROM work;
+    | %sql -a '{"timeout":10, "mode":"ro"}' sqlite:// SELECT * from work;
 
 .. _`SQLAlchemy Args`: https://docs.sqlalchemy.org/en/13/core/engines.html#custom-dbapi-args
 
@@ -200,18 +200,18 @@ refer to your database.
 
 For example, if dsn.ini contains 
 
-    [DB_CONFIG_1]
-    drivername=postgres
-    host=my.remote.host
-    port=5433
-    database=mydatabase
-    username=myuser
-    password=1234
+    | [DB_CONFIG_1] 
+    | drivername=postgres 
+    | host=my.remote.host 
+    | port=5433 
+    | database=mydatabase 
+    | username=myuser 
+    | password=1234
 
 then you can  
 
-    %config SqlMagic.dsn_filename='./dsn.ini'
-    %sql --section DB_CONFIG_1 
+    | %config SqlMagic.dsn_filename='./dsn.ini'
+    | %sql --section DB_CONFIG_1 
 
 Configuration
 -------------

--- a/src/sql/parse.py
+++ b/src/sql/parse.py
@@ -16,7 +16,7 @@ def connection_from_dsn_section(section, config):
     return str(URL(**cfg_dict))
 
 
-def _connection_string(s):
+def _connection_string(s, config):
 
     s = expandvars(s)  # for environment variables
     if "@" in s or "://" in s:
@@ -46,7 +46,7 @@ def parse(cell, config):
     pieces = cell.split(None, 3)
     if not pieces:
         return result
-    result["connection"] = _connection_string(pieces[0])
+    result["connection"] = _connection_string(pieces[0], config)
     if result["connection"]:
         pieces.pop(0)
     if len(pieces) > 1 and pieces[1] == "<<":


### PR DESCRIPTION
- Fixes the README.rst so that the ini config is displayed with line breaks as expected
- Fixes config reference pass in `_connection_string()` to enable parsing config section name correctly 
