### PR TITLE
Add DatabaseError in to handle MySQL exceptions correctly in magic.py

### DIFF
--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -11,7 +11,8 @@ from IPython.core.magic import (
 )
 from IPython.core.magic_arguments import argument, magic_arguments, parse_argstring
 from IPython.display import display_javascript
-from sqlalchemy.exc import OperationalError, ProgrammingError
+# JA: added DatabaseError
+from sqlalchemy.exc import OperationalError, ProgrammingError, DatabaseError
 
 import sql.connection
 import sql.parse
@@ -257,7 +258,8 @@ class SqlMagic(Magics, Configurable):
                 # Return results into the default ipython _ variable
                 return result
 
-        except (ProgrammingError, OperationalError) as e:
+        # JA: added DatabaseError
+        except (ProgrammingError, OperationalError, DatabaseError) as e:
             # Sqlite apparently return all errors as OperationalError :/
             if self.short_errors:
                 print(e)

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -11,7 +11,7 @@ from IPython.core.magic import (
 )
 from IPython.core.magic_arguments import argument, magic_arguments, parse_argstring
 from IPython.display import display_javascript
-# JA: added DatabaseError
+# JA: added DatabaseError for MySQL
 from sqlalchemy.exc import OperationalError, ProgrammingError, DatabaseError
 
 import sql.connection
@@ -258,7 +258,7 @@ class SqlMagic(Magics, Configurable):
                 # Return results into the default ipython _ variable
                 return result
 
-        # JA: added DatabaseError
+        # JA: added DatabaseError for MySQL
         except (ProgrammingError, OperationalError, DatabaseError) as e:
             # Sqlite apparently return all errors as OperationalError :/
             if self.short_errors:

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -148,9 +148,11 @@ class SqlMagic(Magics, Configurable):
 
         """
         # Parse variables (words wrapped in {}) for %%sql magic (for %sql this is done automatically)
-        cell_variables = [
-            fn for _, fn, _, _ in Formatter().parse(cell) if fn is not None
-        ]
+        # possible fix to issue #194 https://github.com/catherinedevlin/ipython-sql/issues/194
+        cell_variables = re.findall(r"{(\w+)}", cell)
+        # cell_variables = [
+        #     fn for _, fn, _, _ in Formatter().parse(cell) if fn is not None
+        # ]
         cell_params = {}
         for variable in cell_variables:
             if variable in local_ns:


### PR DESCRIPTION
Hi Catherine, MySQL returns a DatabaseError instead of OperationalError. This also covers other exceptions like IntegrityError. Please add this to magic.py. Thanks for maintaining this library!

Best, Jens