### PR TITLE
Exclude bigquery dialect from autocommit

### DIFF
--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -331,7 +331,7 @@ class FakeResultProxy(object):
 
 # some dialects have autocommit
 # specific dialects break when commit is used:
-_COMMIT_BLACKLIST_DIALECTS = ("mssql", "clickhouse", "teradata", "athena", "vertica")
+_COMMIT_BLACKLIST_DIALECTS = ("mssql", "clickhouse", "teradata", "athena", "vertica", "bigquery")
 
 
 def _commit(conn, config):


### PR DESCRIPTION
Autocommit breaks bigquery operations because they have their [own restrictions on transactions](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-manipulation-language) and don't support commits.