### PR TITLE
Actian Avalanche, Actian X, Ingres, and Vector support

### DIFF
--- a/src/sql/run.py
+++ b/src/sql/run.py
@@ -331,7 +331,7 @@ class FakeResultProxy(object):
 
 # some dialects have autocommit
 # specific dialects break when commit is used:
-_COMMIT_BLACKLIST_DIALECTS = ("mssql", "clickhouse", "teradata", "athena", "vertica")
+_COMMIT_BLACKLIST_DIALECTS = ("athena", "clickhouse", "ingres", "mssql", "teradata", "vertica")
 
 
 def _commit(conn, config):


### PR DESCRIPTION
Added ingres to the list of databases that are autocommit.

Sorted _COMMIT_BLACKLIST_DIALECTS tuple alphabetically.