### PR TITLE
fix `%sql --close <sqlalchemy_connection_string>` error

### DIFF
--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -101,13 +101,14 @@ class Connection(object):
                 template = "   {}"
             result.append(template.format(engine_url.__repr__()))
         return "\n".join(result)
+    
     @classmethod
     def _close(cls, descriptor):
         if isinstance(descriptor, Connection):
             conn = descriptor
         else:
             conn = cls.connections.get(descriptor) or cls.connections.get(
-                descriptor.lower()
+                descriptor.lower() or cls.connections.get(descriptor.rsplit('//')[0]+'//'+descriptor.rsplit('//')[1].replace('+',' '))
             )
         if not conn:
             raise Exception(

--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -101,7 +101,7 @@ class Connection(object):
                 template = "   {}"
             result.append(template.format(engine_url.__repr__()))
         return "\n".join(result)
-
+    @classmethod
     def _close(cls, descriptor):
         if isinstance(descriptor, Connection):
             conn = descriptor

--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -104,7 +104,6 @@ class Connection(object):
     
     @classmethod
     def _close(cls, descriptor):
-        descriptor = descriptor.rsplit('//')[0]+'//'+descriptor.rsplit('//')[1].replace('+',' ')
         if isinstance(descriptor, Connection):
             conn = descriptor
         else:
@@ -116,7 +115,7 @@ class Connection(object):
                 "Could not close connection because it was not found amongst these: %s"
                 % str(cls.connections.keys())
             )
-        cls.connections.pop(descriptor)
+        cls.connections.pop(str(conn.metadata.bind.url))
         conn.session.close()
 
     def close(self):

--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -104,11 +104,12 @@ class Connection(object):
     
     @classmethod
     def _close(cls, descriptor):
+        descriptor = descriptor.rsplit('//')[0]+'//'+descriptor.rsplit('//')[1].replace('+',' ')
         if isinstance(descriptor, Connection):
             conn = descriptor
         else:
             conn = cls.connections.get(descriptor) or cls.connections.get(
-                descriptor.lower() or cls.connections.get(descriptor.rsplit('//')[0]+'//'+descriptor.rsplit('//')[1].replace('+',' '))
+                descriptor.lower()
             )
         if not conn:
             raise Exception(

--- a/src/sql/connection.py
+++ b/src/sql/connection.py
@@ -116,8 +116,7 @@ class Connection(object):
                 "Could not close connection because it was not found amongst these: %s"
                 % str(cls.connections.keys())
             )
-        cls.connections.pop(conn.name)
-        cls.connections.pop(str(conn.metadata.bind.url))
+        cls.connections.pop(descriptor)
         conn.session.close()
 
     def close(self):


### PR DESCRIPTION
- This adds `@classmethod`, else `sql.connection.Connection._close(args.close)` from 
https://github.com/catherinedevlin/ipython-sql/blob/12f9742a0a4eded514cc95377c920330ccba5e72/src/sql/magic.py#L166
will get an error saying that descriptor argument is required. `@classmethod` will allow `self` to be passed through, and `args.close` will correctly pass as an argument for `descriptor`.

`descriptor` is a connection string.

- This removes `cls.connections.pop(conn.name)`, else it will have a key error when attempting to pop an invalid key from the dictionary of connections.  This line isn't necessary from what I can see.  Perhaps someone else with a different use case may need this can chime in after testing.