### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,9 @@ setup(
     author="Catherine Devlin",
     author_email="catherine.devlin@gmail.com",
     url="https://pypi.python.org/pypi/ipython-sql",
+    project_urls={
+        "Source": "https://github.com/catherinedevlin/ipython-sql",
+    },
     license="MIT",
     packages=find_packages("src"),
     package_dir={"": "src"},


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)