### PR TITLE
Enable syntax highlighting

### DIFF
--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -286,9 +286,12 @@ class SqlMagic(Magics, Configurable):
 def load_ipython_extension(ip):
     """Load the extension in IPython."""
 
-    # this fails in both Firefox and Chrome for OS X.
-    # I get the error: TypeError: IPython.CodeCell.config_defaults is undefined
-
-    # js = "IPython.CodeCell.config_defaults.highlight_modes['magic_sql'] = {'reg':[/^%%sql/]};"
-    # display_javascript(js, raw=True)
+    js = """
+        let codeCell = (Jupyter ?? IPython).CodeCell;
+        let highlightModes = (codeCell.options_default ?? codeCell.config_defaults).highlight_modes;
+        if (!highlightModes['magic_sql'])
+            highlightModes['magic_sql'] = {'reg': []};
+        highlightModes['magic_sql']['reg'].push(/^%%sql/);
+    """
+    display_javascript(js, raw=True)
     ip.register_magics(SqlMagic)

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -287,11 +287,13 @@ def load_ipython_extension(ip):
     """Load the extension in IPython."""
 
     js = """
-        let codeCell = (Jupyter ?? IPython).CodeCell;
-        let highlightModes = (codeCell.options_default ?? codeCell.config_defaults).highlight_modes;
-        if (!highlightModes['magic_sql'])
-            highlightModes['magic_sql'] = {'reg': []};
-        highlightModes['magic_sql']['reg'].push(/^%%sql/);
+        let codeCell = (window.Jupyter ?? window.IPython)?.CodeCell;
+        if (codeCell) {
+            let highlightModes = (codeCell.options_default ?? codeCell.config_defaults).highlight_modes;
+            if (!highlightModes['magic_sql'])
+                highlightModes['magic_sql'] = {'reg': []};
+            highlightModes['magic_sql']['reg'].push(/^%%sql/);
+        }
     """
     display_javascript(js, raw=True)
     ip.register_magics(SqlMagic)


### PR DESCRIPTION
I went to see about adding this and saw that there was already some code to do this.  It was commented out, and a comment suggests that this was related to an API change within Jupyter itself (https://github.com/catherinedevlin/ipython-sql/commit/1a754661354c7339b7bea1c6b6c13324b110d03f).  I've tried to write it in a way that works with both the old and newer APIs, but I've only tested on notebook 6.4.11.

This does not work with JupyterLab, which seems to make this more difficult, likely requiring an extension.